### PR TITLE
Disable SSL verification locally, not globally

### DIFF
--- a/exercises/1-the-manual-menace/README.md
+++ b/exercises/1-the-manual-menace/README.md
@@ -330,7 +330,7 @@ ansible-playbook apply.yml -e target=tools \
 Note - we would not normally make the project under your name but create a group and add the project there on residency but for simplicity of the exercise we'll do that here
 </p> -->
 
-3. If you have not used Git before; you may need to tell Git who you are and what your email is before we commit. Run the following commands, substituting your email and "Your Name". If you've done this before move on to the next step. The last git config command is used to bypass SSL key verification for the GitLab server instance since we are using self-signed certificates on the sever.
+3. If you have not used Git before; you may need to tell Git who you are and what your email is before we commit. Run the following commands, substituting your email and "Your Name". If you've done this before move on to the next step. The last git config command is used to bypass SSL key verification in this repo since we are using self-signed certificates on the GitLab sever.
 
 ```bash
 git config --global user.email "yourname@mail.com"
@@ -340,7 +340,7 @@ git config --global user.name "Your Name"
 ```
 
 ```bash
-git config --global http.sslVerify false
+git config http.sslVerify false
 ```
 
 4. Commit your local project to this new remote by first removing the existing origin (github) where the Ansible project was cloned from in the first steps. Remember to substitute `<GIT_URL>` accordingly with the one created for your `enablement-ci-cd` repository a moment ago.

--- a/exercises/2-attack-of-the-pipelines/README.md
+++ b/exercises/2-attack-of-the-pipelines/README.md
@@ -107,8 +107,9 @@ git checkout develop
 
 2. Open up Gitlab and login. Create a new project (internal) in GitLab called `todolist-fe` to host your clone of the project and copy its remote address. ![new-gitlab-proj](../images/exercise2/new-gitlab-proj.png)
 
-3. In your local clone of the `todolist-fe`, remove the origin and add the GitLab origin by replacing `<YOUR_GIT_LAB_PROJECT>`. Push your app to GitLab
+3. In your local clone of the `todolist-fe`, remove the origin and add the GitLab origin by replacing `<YOUR_GIT_LAB_PROJECT>`. Push your app to GitLab. (As before, we will bypass SSL key verification in this repo since we are using self-signed certificates on the GitLab sever.)
 ```bash
+git config http.sslVerify false
 git remote set-url origin <YOUR_GIT_LAB_PROJECT>
 # verify the origin has been updated
 git remote -v
@@ -244,8 +245,9 @@ git checkout develop
 
 2. On GitLab; create a new project (internal) called `todolist-api` to host your clone of the project and copy its remote address as you did for the previous repositories.
 
-3. In your local clone of the `todolist-api`, remove the origin and add the GitLab origin by replacing `<YOUR_GIT_LAB_PROJECT>`. Push your app to GitLab
+3. In your local clone of the `todolist-api`, remove the origin and add the GitLab origin by replacing `<YOUR_GIT_LAB_PROJECT>`. Push your app to GitLab. (As before, we will bypass SSL key verification in this repo since we are using self-signed certificates on the GitLab sever.) 
 ```bash
+git config http.sslVerify false
 git remote set-url origin <YOUR_GIT_LAB_PROJECT>
 ```
 ```bash


### PR DESCRIPTION
Resolves https://github.com/RedHatTraining/DO500/issues/47

Disabling verification globally disables an important security measure for all repositories on the computer. Cloud-based Git providers such as gitlab.com and GitHub have valid SSL certs and rely on this verification step to prevent an attacker from reading private code or introducing malicious code.

This PR disables SSL verification locally instead, allowing us to use self-signed certs in the DO500 GitLab repo while allowing verification for other repos.